### PR TITLE
fix: remove CheckboxGroup div rest

### DIFF
--- a/packages/components/src/checkbox/index.tsx
+++ b/packages/components/src/checkbox/index.tsx
@@ -28,21 +28,17 @@ export const Checkbox = React.forwardRef<
 
 Checkbox.displayName = CheckboxPrimitive.Root.displayName
 
-type Merge<P, T> = Omit<P, keyof T> & T
-
-export type CheckboxGroupProps<T extends string | number> = Merge<
-  React.ComponentPropsWithoutRef<"div">,
-  {
-    options: {
-      label: string
-      value: T
-    }[]
-    checked: T[]
-    onCheckedChange: (checked: T[]) => void
-    defaultCheckedAll?: boolean
-    checkAllText?: string
-  }
->
+export type CheckboxGroupProps<T extends string | number> = {
+  options: {
+    label: string
+    value: T
+  }[]
+  checked: T[]
+  onCheckedChange: (checked: T[]) => void
+  defaultCheckedAll?: boolean
+  checkAllText?: string
+  className?: string
+}
 
 export function CheckboxGroup<T extends string | number>(
   props: CheckboxGroupProps<T>,
@@ -54,7 +50,6 @@ export function CheckboxGroup<T extends string | number>(
     className = "",
     defaultCheckedAll = false,
     checkAllText = "Check All",
-    ...rest
   } = props
 
   const allChecked: CheckedState =
@@ -84,10 +79,7 @@ export function CheckboxGroup<T extends string | number>(
   }, [defaultCheckedAll, options.length])
 
   return (
-    <div
-      className={cn("flex items-center flex-wrap gap-2", className)}
-      {...rest}
-    >
+    <div className={cn("flex items-center flex-wrap gap-2", className)}>
       <Checkbox
         checked={allChecked}
         onCheckedChange={handleAllCheckedChange}


### PR DESCRIPTION
div 接受 rest 会导致原本应属于 CheckboxGourp 的表单状态同时受 div 控制，点击 div 会使 CheckboxGourp 的表单状态变成 Boolean，暂时先考虑移除